### PR TITLE
fix: resolve remaining ESLint warnings

### DIFF
--- a/src/components/blog/PostImage.tsx
+++ b/src/components/blog/PostImage.tsx
@@ -25,6 +25,7 @@ const PostImage = ({ src, alt, title }: PostImageProps) => {
 
   return (
     <div className="my-6 flex justify-center">
+      {/* eslint-disable-next-line jsx-a11y/alt-text -- zimme-zoom's Image takes alt via the image object, not an alt prop */}
       <Image
         image={image}
         size={{

--- a/src/components/general/current-focus/CurrentFocus.tsx
+++ b/src/components/general/current-focus/CurrentFocus.tsx
@@ -5,7 +5,7 @@ import Title from "../typography/Title";
 import Paragraph from "../typography/Paragraph";
 import Link from "../typography/Link";
 import Image from "next/image";
-import { useRef, useState, useEffect } from "react";
+import { useRef, useState } from "react";
 import programmingSvg from "./programming.svg";
 import aiToolingSvg from "./ai-tooling.svg";
 import openSourceSvg from "./open-source.svg";
@@ -112,28 +112,6 @@ const CurrentFocus = () => {
   const handleTouchEnd = () => {
     setIsDragging(false);
   };
-
-  useEffect(() => {
-    const handleMouseLeave = () => {
-      setIsDragging(false);
-    };
-
-    if (scrollContainerRef.current) {
-      scrollContainerRef.current.addEventListener(
-        "mouseleave",
-        handleMouseLeave
-      );
-    }
-
-    return () => {
-      if (scrollContainerRef.current) {
-        scrollContainerRef.current.removeEventListener(
-          "mouseleave",
-          handleMouseLeave
-        );
-      }
-    };
-  }, []);
 
   return (
     <div style={{ fontSize: "0.85em", lineHeight: "1.0" }}>


### PR DESCRIPTION
## Summary
Cleans up the two remaining ESLint warnings so yarn lint reports zero warnings.
Build passes.

## Changes
- Remove a redundant mouseleave useEffect in CurrentFocus: the container's onMouseLeave handler already resets the dragging state, and the effect triggered the react-hooks/exhaustive-deps warning on the ref used in its cleanup
- Suppress a jsx-a11y/alt-text false positive in PostImage: zimme-zoom's Image component receives alt via the image object, not an alt prop