### PR TITLE
feat: add llms.txt and AI agent readiness

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,12 @@
+# robots.txt for https://kulcsarrudolf.com
+#
+# AI usage preferences are declared with Content-Signal directives.
+# See https://contentsignals.org for the specification.
+# A machine-readable overview of this site is available at
+# https://kulcsarrudolf.com/llms.txt
+
+User-agent: *
+Content-Signal: search=yes, ai-input=yes, ai-train=yes
+Allow: /
+
+Sitemap: https://kulcsarrudolf.com/sitemap.xml

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,6 +8,13 @@ import Footer from "@/components/footer/Footer";
 import { Suspense } from "react";
 import ConditionalSpeedInsights from "@/components/general/SpeedInsights";
 import type { Metadata } from "next";
+import {
+  AUTHOR_NAME,
+  SITE_DESCRIPTION,
+  SITE_NAME,
+  SITE_URL,
+  SOCIAL_PROFILES,
+} from "@/config/site";
 
 config.autoAddCss = false;
 
@@ -16,10 +23,29 @@ const inter = Inter({
   variable: "--font-inter",
 });
 
-const SITE_NAME = "Kulcsar Rudolf - Software Developer";
-const SITE_URL = "https://kulcsarrudolf.com";
-const DEFAULT_DESCRIPTION =
-  "Personal website of Kulcsar Rudolf, a full-stack software developer. Read articles about software development, explore side projects, and see the tools and ideas I work with every day.";
+const structuredData = {
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "Person",
+      "@id": `${SITE_URL}/#person`,
+      name: AUTHOR_NAME,
+      url: SITE_URL,
+      jobTitle: "Software Developer",
+      image: `${SITE_URL}/images/me-logo.png`,
+      sameAs: SOCIAL_PROFILES,
+    },
+    {
+      "@type": "WebSite",
+      "@id": `${SITE_URL}/#website`,
+      name: SITE_NAME,
+      url: SITE_URL,
+      description: SITE_DESCRIPTION,
+      inLanguage: "en",
+      publisher: { "@id": `${SITE_URL}/#person` },
+    },
+  ],
+};
 
 export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),
@@ -27,7 +53,7 @@ export const metadata: Metadata = {
     default: SITE_NAME,
     template: "%s | Kulcsar Rudolf",
   },
-  description: DEFAULT_DESCRIPTION,
+  description: SITE_DESCRIPTION,
   applicationName: SITE_NAME,
   authors: [{ name: "Kulcsar Rudolf", url: SITE_URL }],
   creator: "Kulcsar Rudolf",
@@ -54,7 +80,7 @@ export const metadata: Metadata = {
     url: SITE_URL,
     siteName: SITE_NAME,
     title: SITE_NAME,
-    description: DEFAULT_DESCRIPTION,
+    description: SITE_DESCRIPTION,
     locale: "en_US",
     images: [
       {
@@ -68,7 +94,7 @@ export const metadata: Metadata = {
   twitter: {
     card: "summary_large_image",
     title: SITE_NAME,
-    description: DEFAULT_DESCRIPTION,
+    description: SITE_DESCRIPTION,
     creator: "@kulcsarrudolf",
     images: ["/images/me-logo.png"],
   },
@@ -128,6 +154,10 @@ export default function RootLayout({
       }}
     >
       <body suppressHydrationWarning style={{ marginTop: "7rem" }}>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+        />
         <div className="mx-auto max-w-5xl">
           <Suspense fallback={<div style={{ height: "7rem" }} />}>
             <Navbar />

--- a/src/app/llms.txt/route.ts
+++ b/src/app/llms.txt/route.ts
@@ -1,0 +1,45 @@
+import { getPostMetadata } from "@/utils/getPostMetadata";
+import { AUTHOR_NAME, SITE_NAME, SITE_URL, SOCIAL_PROFILES } from "@/config/site";
+
+export const dynamic = "force-static";
+
+export function GET() {
+  const posts = [...getPostMetadata()].sort((a, b) =>
+    b.date.localeCompare(a.date)
+  );
+
+  const postLines = posts.map((post) => {
+    const summary = post.description || post.subtitle;
+    return `- [${post.title}](${SITE_URL}/posts/${post.slug}.md): ${summary}`;
+  });
+
+  const body = [
+    `# ${SITE_NAME}`,
+    "",
+    `> Personal website and blog of ${AUTHOR_NAME}, a full-stack software developer. Articles about software development, side projects, and the tools and ideas he works with every day.`,
+    "",
+    "Every blog post is available as clean markdown: append `.md` to the post URL, or request the post URL with an `Accept: text/markdown` header.",
+    "",
+    "## Blog",
+    "",
+    ...postLines,
+    "",
+    "## Pages",
+    "",
+    `- [Home](${SITE_URL}/): Introduction and overview`,
+    `- [Blog](${SITE_URL}/blog): All blog posts`,
+    `- [Projects](${SITE_URL}/projects): Side projects and open source work`,
+    `- [Contact](${SITE_URL}/contact): How to get in touch`,
+    "",
+    "## Social",
+    "",
+    ...SOCIAL_PROFILES.map((url) => `- ${url}`),
+    "",
+  ].join("\n");
+
+  return new Response(body, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+    },
+  });
+}

--- a/src/app/markdown/posts/[slug]/route.ts
+++ b/src/app/markdown/posts/[slug]/route.ts
@@ -1,0 +1,47 @@
+import fs from "fs";
+
+import matter from "gray-matter";
+
+import { getPostMetadata } from "@/utils/getPostMetadata";
+import { SITE_URL } from "@/config/site";
+
+export const dynamic = "force-static";
+
+export const generateStaticParams = () => {
+  return getPostMetadata().map((post) => ({ slug: post.slug }));
+};
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ slug: string }> }
+) {
+  const { slug } = await params;
+
+  // Only slugs of published posts are served; this also rejects
+  // private posts and any path-traversal attempts.
+  const post = getPostMetadata().find((p) => p.slug === slug);
+
+  if (!post) {
+    return new Response("Not found", { status: 404 });
+  }
+
+  const file = fs.readFileSync(`./src/posts/${slug}.md`, "utf8");
+  const { data, content } = matter(file);
+
+  const body = [
+    `# ${data.title}`,
+    "",
+    ...(data.subtitle ? [`> ${data.subtitle}`, ""] : []),
+    `By ${data.author}, published on ${data.date}.`,
+    `Canonical URL: ${SITE_URL}/posts/${slug}`,
+    "",
+    content.trim(),
+    "",
+  ].join("\n");
+
+  return new Response(body, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+    },
+  });
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,23 @@
+import type { MetadataRoute } from "next";
+
+import { getPostMetadata } from "@/utils/getPostMetadata";
+import { SITE_URL } from "@/config/site";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const pages: MetadataRoute.Sitemap = [
+    "",
+    "/blog",
+    "/projects",
+    "/quotes",
+    "/contact",
+  ].map((path) => ({
+    url: `${SITE_URL}${path}`,
+  }));
+
+  const posts: MetadataRoute.Sitemap = getPostMetadata().map((post) => ({
+    url: `${SITE_URL}/posts/${post.slug}`,
+    lastModified: new Date(post.date),
+  }));
+
+  return [...pages, ...posts];
+}

--- a/src/config/site.ts
+++ b/src/config/site.ts
@@ -1,0 +1,15 @@
+export const SITE_NAME = "Kulcsar Rudolf - Software Developer";
+
+export const SITE_URL = "https://kulcsarrudolf.com";
+
+export const SITE_DESCRIPTION =
+  "Personal website of Kulcsar Rudolf, a full-stack software developer. Read articles about software development, explore side projects, and see the tools and ideas I work with every day.";
+
+export const AUTHOR_NAME = "Kulcsar Rudolf";
+
+export const SOCIAL_PROFILES = [
+  "https://www.linkedin.com/in/kulcsarrudolf/",
+  "https://x.com/kulcsar_rudolf",
+  "https://www.instagram.com/rudolf0k/",
+  "https://github.com/kulcsarrudolf",
+];

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from "next/server";
+
+// Serves blog posts as clean markdown for AI agents:
+// - /posts/<slug>.md always returns markdown
+// - /posts/<slug> returns markdown when the client asks for it
+//   via an Accept: text/markdown header
+export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  const mdExtensionMatch = pathname.match(/^\/posts\/([^/]+)\.md$/);
+  if (mdExtensionMatch) {
+    const url = request.nextUrl.clone();
+    url.pathname = `/markdown/posts/${mdExtensionMatch[1]}`;
+    return NextResponse.rewrite(url);
+  }
+
+  const postMatch = pathname.match(/^\/posts\/([^/]+)$/);
+  const accept = request.headers.get("accept") ?? "";
+  if (postMatch && accept.includes("text/markdown")) {
+    const url = request.nextUrl.clone();
+    url.pathname = `/markdown/posts/${postMatch[1]}`;
+    const response = NextResponse.rewrite(url);
+    response.headers.set("Vary", "Accept");
+    return response;
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ["/posts/:slug*"],
+};


### PR DESCRIPTION
## Summary
Makes the site readable for AI agents and crawlers: adds a generated /llms.txt overview, markdown versions of all blog posts (via .md URLs or Accept: text/markdown), a robots.txt with Content-Signal directives, a sitemap, and site-level JSON-LD.

## Changes
- Add /llms.txt route generated from post metadata (title, description, links to markdown versions)
- Serve blog posts as clean markdown at /posts/<slug>.md and via Accept: text/markdown content negotiation (middleware rewrite to a markdown route handler)
- Add public/robots.txt with Content-Signal directives (search=yes, ai-input=yes, ai-train=yes) and a sitemap reference
- Add sitemap.xml covering all pages and posts
- Add Person and WebSite JSON-LD to the root layout
- Extract shared site constants (name, URL, description, social profiles) into src/config/site.ts