### PR TITLE
chore: isolate preview server build directory

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -6,7 +6,10 @@
       "runtimeExecutable": "yarn",
       "runtimeArgs": ["dev"],
       "port": 3000,
-      "autoPort": true
+      "autoPort": true,
+      "env": {
+        "NEXT_DIST_DIR": ".next-preview"
+      }
     }
   ]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 
 # next.js
 /.next/
+/.next-preview/
 /out/
 
 # production

--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,9 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {}
+const nextConfig = {
+  // Allow a separate build directory per running instance so that two
+  // concurrent `next dev` processes (e.g. your local server and a
+  // preview/verification server) never clobber each other's chunks.
+  distDir: process.env.NEXT_DIST_DIR || ".next",
+};
 
-module.exports = nextConfig
+module.exports = nextConfig;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -20,9 +24,19 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": [
+        "./src/*"
+      ]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    "next-env.d.ts",
+    ".next-preview/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Summary
Fixes the repeated `ChunkLoadError` / missing-vendor-chunk crashes during local development. They were caused by two concurrent `next dev` processes (the local dev server and the preview/verification server) writing to the same `.next` folder and overwriting each other's chunk files. This gives each instance its own build directory.

## Changes
- `next.config.js` reads the build directory from `NEXT_DIST_DIR` (defaults to `.next`)
- `.claude/launch.json` runs the preview server with `NEXT_DIST_DIR=.next-preview`
- `.gitignore` ignores `.next-preview`
- `tsconfig.json` include paths auto-synced by Next.js for the new build dir