### PR TITLE
content: unpublish Koszikla post as draft

### DIFF
--- a/src/posts/building-koszikla-a-church-app-with-an-ai-sermon-agent.md
+++ b/src/posts/building-koszikla-a-church-app-with-an-ai-sermon-agent.md
@@ -18,7 +18,7 @@ keywords:
     "twilio",
     "open source",
   ]
-private: false
+private: true
 ---
 
 ## Introduction


### PR DESCRIPTION
## Summary
Turns the "Building Kőszikla" post back into a draft by setting `private: true` in its frontmatter.

## Changes
- `building-koszikla-a-church-app-with-an-ai-sermon-agent.md`: `private: false` -> `private: true`, which hides it from the blog list, 404s its page, and excludes it from `llms.txt` and the sitemap