### PR TITLE
feat: show draft posts in local development

### DIFF
--- a/src/app/posts/[slug]/page.tsx
+++ b/src/app/posts/[slug]/page.tsx
@@ -8,7 +8,7 @@ import { Suspense } from "react";
 import PostBody from "@/components/blog/PostBody";
 import { Title, Subtitle } from "@/components/general/typography";
 
-import { getPostMetadata } from "@/utils/getPostMetadata";
+import { getPostMetadata, shouldShowPrivatePosts } from "@/utils/getPostMetadata";
 import PostedOn from "@/components/general/PostedOn";
 
 const getPostContent = (slug: string) => {
@@ -94,7 +94,7 @@ const PostPage = async ({ params }: { params: Params }) => {
   const { slug } = await params;
   const post = getPostContent(slug);
 
-  if (post.data.private === true) {
+  if (post.data.private === true && !shouldShowPrivatePosts()) {
     notFound();
   }
 

--- a/src/utils/getPostMetadata.ts
+++ b/src/utils/getPostMetadata.ts
@@ -3,6 +3,11 @@ import matter from "gray-matter";
 
 import BlogPost from "@/types/blog-post.type";
 
+// Draft posts (private: true) are visible on the local dev server so they
+// can be previewed, but stay hidden in the production build.
+export const shouldShowPrivatePosts = (): boolean =>
+  process.env.NODE_ENV === "development";
+
 export const getPostMetadata = (): BlogPost[] => {
   const folder = "./src/posts";
 
@@ -30,6 +35,10 @@ export const getPostMetadata = (): BlogPost[] => {
       private: matterResult.data.private === true,
     };
   });
+
+  if (shouldShowPrivatePosts()) {
+    return posts;
+  }
 
   return posts.filter((post) => !post.private);
 };


### PR DESCRIPTION
## Summary
Makes draft posts (`private: true`) visible on the local dev server so they can be previewed, while keeping them hidden in the production build.

## Changes
- Add `shouldShowPrivatePosts()` helper in `getPostMetadata.ts`, gated on `NODE_ENV === "development"`
- Include private posts in `getPostMetadata` (blog list, llms.txt, sitemap) when in dev
- Skip the post-page 404 guard for private posts when in dev

Verified: in dev the draft page returns 200 and appears in the blog list and llms.txt; in a production build it is not prerendered and is absent from llms.txt.