### PR TITLE
content: update current focus employer and tooling

### DIFF
--- a/src/components/general/current-focus/CurrentFocus.tsx
+++ b/src/components/general/current-focus/CurrentFocus.tsx
@@ -14,8 +14,8 @@ import aiIntegrationSvg from "./ai-integration.svg";
 const CurrentFocus = () => {
   const { t } = useTranslation();
 
-  const TheBriefAILink = () => (
-    <Link href="https://thebrief.ai">The Brief AI</Link>
+  const InnovatorSparkLink = () => (
+    <Link href="https://innovatorspark.com/">InnovatorSpark</Link>
   );
   const ReactLink = () => <Link href="https://react.dev">React</Link>;
   const NodeJSLink = () => <Link href="https://nodejs.org">Node.js</Link>;
@@ -23,11 +23,9 @@ const CurrentFocus = () => {
     <Link href="https://github.com/kulcsarrudolf">personal projects</Link>
   );
 
-  const CursorLink = () => <Link href="https://cursor.sh">Cursor</Link>;
   const ClaudeCodeLink = () => (
     <Link href="https://www.anthropic.com/claude">Claude Code</Link>
   );
-  const ZedLink = () => <Link href="https://zed.dev">Zed</Link>;
 
   const ZimmeZoomLink = () => (
     <Link href="https://github.com/kulcsarrudolf/zimme-zoom">zimme-zoom</Link>
@@ -159,16 +157,14 @@ const CurrentFocus = () => {
               <Paragraph>
                 {area.key === "fullStack" &&
                   t(`home.currentFocus.${area.key}.description`, {
-                    theBriefAI: <TheBriefAILink />,
+                    innovatorSpark: <InnovatorSparkLink />,
                     react: <ReactLink />,
                     nodejs: <NodeJSLink />,
                     personalProjects: <PersonalProjectsLink />,
                   })}
                 {area.key === "aiTooling" &&
                   t(`home.currentFocus.${area.key}.description`, {
-                    cursor: <CursorLink />,
                     claudeCode: <ClaudeCodeLink />,
-                    zed: <ZedLink />,
                   })}
                 {area.key === "aiIntegration" &&
                   t(`home.currentFocus.${area.key}.description`)}

--- a/src/i18n/translations/en.json
+++ b/src/i18n/translations/en.json
@@ -18,11 +18,11 @@
       "title": "Currently Focused On",
       "fullStack": {
         "title": "Full-Stack Development",
-        "description": "Working at {theBriefAI} with {react} and {nodejs}. Always exploring and adopting new technologies and development practices by working on {personalProjects}."
+        "description": "Working at {innovatorSpark} with {react} and {nodejs}. Always exploring and adopting new technologies and development practices by working on {personalProjects}."
       },
       "aiTooling": {
         "title": "AI Tooling",
-        "description": "Staying current with the fast-changing AI tooling ecosystem to enhance workflow and productivity. Currently I use {cursor} and {claudeCode} (with {zed}) to speed up my coding work."
+        "description": "Staying current with the fast-changing AI tooling ecosystem to enhance workflow and productivity. Currently I use {claudeCode} to speed up my coding work."
       },
       "aiIntegration": {
         "title": "AI Integration",

--- a/src/i18n/translations/hu.json
+++ b/src/i18n/translations/hu.json
@@ -18,11 +18,11 @@
       "title": "Jelenleg ezekre fókuszálok",
       "fullStack": {
         "title": "Full-Stack Fejlesztés",
-        "description": "A {theBriefAI}-nál dolgozom {react} és {nodejs} technológiákkal. Folyamatosan felfedezem és alkalmazom az új technológiákat és fejlesztési gyakorlatokat {personalProjects} dolgozásával."
+        "description": "A {innovatorSpark}-nál dolgozom {react} és {nodejs} technológiákkal. Folyamatosan felfedezem és alkalmazom az új technológiákat és fejlesztési gyakorlatokat {personalProjects} dolgozásával."
       },
       "aiTooling": {
         "title": "AI Eszközök",
-        "description": "Naprakész maradok a gyorsan változó AI eszközök ökoszisztémájával, hogy javítsam a munkafolyamatomat és a produktivitásomat. Jelenleg a {cursor} és {claudeCode} ({zed}-dal) eszközöket használom a kódolási munkám felgyorsítására."
+        "description": "Naprakész maradok a gyorsan változó AI eszközök ökoszisztémájával, hogy javítsam a munkafolyamatomat és a produktivitásomat. Jelenleg a {claudeCode} eszközt használom a kódolási munkám felgyorsítására."
       },
       "aiIntegration": {
         "title": "AI Integráció",


### PR DESCRIPTION
## Summary
Updates the "Currently Focused On" section: changes the current employer and trims the AI tooling list.

## Changes
- Change current employer from The Brief AI to InnovatorSpark (https://innovatorspark.com/)
- Remove Cursor and Zed from the AI tooling section, leaving Claude Code
- Drop the now-unused `CursorLink`/`ZedLink` components and update the English and Hungarian translations