### PR TITLE
feat: add projects/diamond page

### DIFF
--- a/src/app/projects/diamond/page.tsx
+++ b/src/app/projects/diamond/page.tsx
@@ -1,0 +1,42 @@
+import { Suspense } from "react";
+import type { Metadata } from "next";
+import DiamondPage from "@/pages/DiamondPage";
+
+const DIAMOND_TITLE = "Diamond";
+const DIAMOND_DESCRIPTION =
+  "Diamond, a project by Kulcsar Rudolf.";
+const DIAMOND_KEYWORDS = [
+  "Kulcsar Rudolf projects",
+  "diamond",
+  "personal project",
+];
+
+export const metadata: Metadata = {
+  title: DIAMOND_TITLE,
+  description: DIAMOND_DESCRIPTION,
+  keywords: DIAMOND_KEYWORDS,
+  alternates: {
+    canonical: "/projects/diamond",
+  },
+  openGraph: {
+    type: "website",
+    url: "https://kulcsarrudolf.com/projects/diamond",
+    title: `${DIAMOND_TITLE} | Kulcsar Rudolf`,
+    description: DIAMOND_DESCRIPTION,
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: `${DIAMOND_TITLE} | Kulcsar Rudolf`,
+    description: DIAMOND_DESCRIPTION,
+  },
+};
+
+const Diamond = () => {
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <DiamondPage />
+    </Suspense>
+  );
+};
+
+export default Diamond;

--- a/src/pages/DiamondPage.tsx
+++ b/src/pages/DiamondPage.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import Link from "next/link";
+import { Paragraph, Subtitle, Title } from "@/components/general/typography";
+
+export default function DiamondPage() {
+  return (
+    <>
+      <Title>Diamond</Title>
+      <p className="text-gray-600 mb-6">
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua.
+      </p>
+
+      <Subtitle>Overview</Subtitle>
+      <Paragraph>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
+        velit esse cillum dolore eu fugiat nulla pariatur.
+      </Paragraph>
+
+      <Subtitle>Details</Subtitle>
+      <Paragraph>
+        Excepteur sint occaecat cupidatat non proident, sunt in culpa qui
+        officia deserunt mollit anim id est laborum. Sed ut perspiciatis unde
+        omnis iste natus error sit voluptatem accusantium doloremque laudantium,
+        totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi
+        architecto beatae vitae dicta sunt explicabo.
+      </Paragraph>
+      <Paragraph>
+        Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut
+        fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem
+        sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor
+        sit amet, consectetur, adipisci velit, sed quia non numquam eius modi
+        tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem.
+      </Paragraph>
+
+      <div className="mt-8 pt-6 border-t border-gray-200 text-center">
+        <p className="text-gray-600 text-sm">
+          Back to{" "}
+          <Link
+            href="/projects"
+            className="hover:underline"
+            style={{ color: "#4267b2" }}
+          >
+            all projects
+          </Link>
+          .
+        </p>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
Adds the `/projects/diamond` route with placeholder lorem ipsum content, following the existing project/page conventions (route file with SEO metadata + page component using shared typography).