### PR TITLE
feat: add URL aliases for /nr wedding page

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -4,6 +4,17 @@ const nextConfig = {
   // concurrent `next dev` processes (e.g. your local server and a
   // preview/verification server) never clobber each other's chunks.
   distDir: process.env.NEXT_DIST_DIR || ".next",
+
+  // Serve the wedding countdown page (/nr) under a few friendlier aliases.
+  // Rewrites keep the URL the visitor typed while rendering the same page,
+  // and query params (e.g. ?lang=ro) are forwarded automatically.
+  async rewrites() {
+    return [
+      { source: "/rn", destination: "/nr" },
+      { source: "/rudolf-es-nora", destination: "/nr" },
+      { source: "/rudolf-and-nora", destination: "/nr" },
+    ];
+  },
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
## Summary
Make the hidden wedding countdown page reachable under friendlier URLs so it can be shared by name.

## Changes
- Rewrite `/rn`, `/rudolf-es-nora`, and `/rudolf-and-nora` to the existing `/nr` page.
- Rewrites keep the typed URL in the address bar and forward query params (e.g. `?lang=ro`).