### PR TITLE
feat: make /nr wedding page multilingual via ?lang param

### DIFF
--- a/src/app/nr/page.tsx
+++ b/src/app/nr/page.tsx
@@ -1,20 +1,34 @@
 import type { Metadata } from "next";
 import WeddingCountdown from "@/components/nr/WeddingCountdown";
+import { getNrContent, getNrLanguage } from "@/components/nr/translations";
 
-export const metadata: Metadata = {
-  title: "Rudolf és Nóra",
-  robots: {
-    index: false,
-    follow: false,
-    googleBot: {
-      index: false,
-      follow: false,
+type SearchParams = Promise<{ lang?: string | string[] }>;
+
+const NOINDEX = {
+  index: false,
+  follow: false,
+} as const;
+
+export async function generateMetadata({
+  searchParams,
+}: {
+  searchParams: SearchParams;
+}): Promise<Metadata> {
+  const { lang } = await searchParams;
+  const content = getNrContent(getNrLanguage(lang));
+
+  return {
+    title: content.names,
+    robots: {
+      ...NOINDEX,
+      googleBot: NOINDEX,
     },
-  },
-};
+  };
+}
 
-const NrPage = () => {
-  return <WeddingCountdown />;
+const NrPage = async ({ searchParams }: { searchParams: SearchParams }) => {
+  const { lang } = await searchParams;
+  return <WeddingCountdown lang={getNrLanguage(lang)} />;
 };
 
 export default NrPage;

--- a/src/components/nr/WeddingCountdown.tsx
+++ b/src/components/nr/WeddingCountdown.tsx
@@ -2,6 +2,11 @@
 
 import { useEffect, useRef, useState } from "react";
 import { Cormorant_Garamond, Great_Vibes } from "next/font/google";
+import {
+  NR_DEFAULT_LANGUAGE,
+  getNrContent,
+  type NrLanguage,
+} from "./translations";
 
 const greatVibes = Great_Vibes({
   subsets: ["latin", "latin-ext"],
@@ -62,7 +67,12 @@ const CountdownTile = ({ value, label }: { value: number; label: string }) => (
   </div>
 );
 
-const WeddingCountdown = () => {
+const WeddingCountdown = ({
+  lang = NR_DEFAULT_LANGUAGE,
+}: {
+  lang?: NrLanguage;
+}) => {
+  const content = getNrContent(lang);
   const [timeLeft, setTimeLeft] = useState<TimeLeft | null>(null);
   const [mounted, setMounted] = useState(false);
   const [photoOk, setPhotoOk] = useState(true);
@@ -126,7 +136,7 @@ const WeddingCountdown = () => {
             <img
               ref={photoRef}
               src="/images/nr.jpeg"
-              alt="Rudolf és Nóra"
+              alt={content.names}
               className="h-44 w-44 rounded-full border-4 border-white object-cover object-top sm:h-60 sm:w-60"
               onError={() => setPhotoOk(false)}
             />
@@ -144,11 +154,11 @@ const WeddingCountdown = () => {
           className="mt-8 text-5xl leading-tight text-[#6d2237] sm:text-7xl"
           style={{ fontFamily: "var(--font-great-vibes), cursive" }}
         >
-          Rudolf és Nóra
+          {content.names}
         </h1>
 
         <p className="mt-3 text-sm uppercase tracking-[0.45em] text-[#8a5a63] sm:text-base">
-          menyegző
+          {content.subtitle}
         </p>
 
         <div className="mt-6 flex items-center gap-3 text-[#c09a5e]">
@@ -161,7 +171,7 @@ const WeddingCountdown = () => {
           className="mt-6 text-2xl text-[#4f2a33] sm:text-3xl"
           style={{ fontFamily: "var(--font-cormorant), serif" }}
         >
-          2026. november 28. · 10:00
+          {content.date}
         </p>
 
         {isWeddingDay ? (
@@ -169,14 +179,14 @@ const WeddingCountdown = () => {
             className="mt-10 text-3xl text-[#6d2237] sm:text-5xl"
             style={{ fontFamily: "var(--font-great-vibes), cursive" }}
           >
-            Eljött a nagy nap! ♥
+            {content.weddingDay}
           </p>
         ) : (
           <div className="mt-10 grid w-full max-w-2xl grid-cols-4 gap-2 sm:gap-4">
-            <CountdownTile value={timeLeft?.days ?? 0} label="nap" />
-            <CountdownTile value={timeLeft?.hours ?? 0} label="óra" />
-            <CountdownTile value={timeLeft?.minutes ?? 0} label="perc" />
-            <CountdownTile value={timeLeft?.seconds ?? 0} label="mp" />
+            <CountdownTile value={timeLeft?.days ?? 0} label={content.labels.days} />
+            <CountdownTile value={timeLeft?.hours ?? 0} label={content.labels.hours} />
+            <CountdownTile value={timeLeft?.minutes ?? 0} label={content.labels.minutes} />
+            <CountdownTile value={timeLeft?.seconds ?? 0} label={content.labels.seconds} />
           </div>
         )}
 
@@ -186,10 +196,10 @@ const WeddingCountdown = () => {
             className="text-2xl italic leading-relaxed text-[#6d2237] sm:text-3xl"
             style={{ fontFamily: "var(--font-cormorant), serif" }}
           >
-            „Megtaláltam azt, akit szeret a lelkem.”
+            {content.quote}
           </blockquote>
           <figcaption className="mt-4 text-xs uppercase tracking-[0.3em] text-[#8a5a63] sm:text-sm">
-            Énekek éneke 3:4
+            {content.quoteReference}
           </figcaption>
           <span className="mx-auto mt-4 block h-10 w-px bg-[#c09a5e]/50" />
         </figure>

--- a/src/components/nr/translations.ts
+++ b/src/components/nr/translations.ts
@@ -1,0 +1,78 @@
+export type NrLanguage = "hu" | "ro" | "en";
+
+export const NR_LANGUAGES: NrLanguage[] = ["hu", "ro", "en"];
+
+export const NR_DEFAULT_LANGUAGE: NrLanguage = "hu";
+
+export function getNrLanguage(lang: string | string[] | undefined): NrLanguage {
+  const value = Array.isArray(lang) ? lang[0] : lang;
+  if (value === "hu" || value === "ro" || value === "en") {
+    return value;
+  }
+  return NR_DEFAULT_LANGUAGE;
+}
+
+interface NrContent {
+  /** Used for the document title and the photo alt text. */
+  names: string;
+  subtitle: string;
+  date: string;
+  weddingDay: string;
+  labels: {
+    days: string;
+    hours: string;
+    minutes: string;
+    seconds: string;
+  };
+  quote: string;
+  quoteReference: string;
+}
+
+export const nrTranslations: Record<NrLanguage, NrContent> = {
+  hu: {
+    names: "Rudolf és Nóra",
+    subtitle: "menyegző",
+    date: "2026. november 28. · 10:00",
+    weddingDay: "Eljött a nagy nap! ♥",
+    labels: {
+      days: "nap",
+      hours: "óra",
+      minutes: "perc",
+      seconds: "mp",
+    },
+    quote: "„Megtaláltam azt, akit szeret a lelkem.”",
+    quoteReference: "Énekek éneke 3:4",
+  },
+  ro: {
+    names: "Rudolf și Nóra",
+    subtitle: "cununie",
+    date: "28 noiembrie 2026 · 10:00",
+    weddingDay: "A sosit ziua cea mare! ♥",
+    labels: {
+      days: "zile",
+      hours: "ore",
+      minutes: "min",
+      seconds: "sec",
+    },
+    quote: "„Am găsit pe cel ce-l iubește sufletul meu.”",
+    quoteReference: "Cântarea Cântărilor 3:4",
+  },
+  en: {
+    names: "Rudolf and Nóra",
+    subtitle: "wedding",
+    date: "November 28, 2026 · 10:00",
+    weddingDay: "The big day is here! ♥",
+    labels: {
+      days: "days",
+      hours: "hours",
+      minutes: "min",
+      seconds: "sec",
+    },
+    quote: "“I have found the one whom my soul loves.”",
+    quoteReference: "Song of Songs 3:4",
+  },
+};
+
+export function getNrContent(lang: NrLanguage): NrContent {
+  return nrTranslations[lang];
+}


### PR DESCRIPTION
## Summary
The wedding countdown page now speaks three languages, selected with the `?lang=` query param: Hungarian by default, plus Romanian and English.

## Changes
- Add a self-contained translation dictionary (`hu` default, `ro`, `en`): names, subtitle, date, tile labels, the Song of Songs verse, and the wedding-day message.
- Read `?lang` server-side and localize both the `<title>` and all on-page text; invalid/missing values fall back to Hungarian.
- Page remains `noindex`.