### PR TITLE
fix: use "nuntă" for Romanian /nr subtitle

### DIFF
--- a/src/components/nr/translations.ts
+++ b/src/components/nr/translations.ts
@@ -45,7 +45,7 @@ export const nrTranslations: Record<NrLanguage, NrContent> = {
   },
   ro: {
     names: "Rudolf și Nóra",
-    subtitle: "cununie",
+    subtitle: "nuntă",
     date: "28 noiembrie 2026 · 10:00",
     weddingDay: "A sosit ziua cea mare! ♥",
     labels: {


### PR DESCRIPTION
## Summary
Switch the Romanian wedding-page subtitle from `cununie` to `nuntă`. "Nuntă" is the general word for a wedding (matching the Hungarian "menyegző"), whereas "cununie" narrowly refers to the marriage ceremony itself.

## Changes
- `src/components/nr/translations.ts`: Romanian `subtitle` → `nuntă`.