### PR TITLE
feat: add markdown content layer for projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,21 @@ Other scripts: `yarn build` (production build), `yarn start` (serve built app), 
 
 Blog posts are written in Markdown and stored in `src/posts/`. To add a new post, create a Markdown file named `post-title.md` and fill in the frontmatter and content. Posts are rendered dynamically on the site. A template is available [here](./src/posts/tempate/template-post.md) to keep formatting consistent.
 
+## Adding a Project
+
+Projects work the same way as blog posts: each one is a Markdown file in `src/projects/`, and the
+file name becomes the URL (`src/projects/pg-seed-kit.md` renders at `/projects/pg-seed-kit`). Copy
+[the template](./src/projects/template/template-project.md), fill in the frontmatter, and keep the
+body short: an intro, a few feature bullets, an install snippet, and links.
+
+Frontmatter worth knowing about:
+
+- `order` controls the position on `/projects`, ascending, defaulting to `100`.
+- `github`, `npm` and `website` are optional and render as links on the project page.
+- `relatedPosts` takes blog post slugs. Private posts are filtered out automatically, so it is
+  safe to reference a draft.
+- `private: true` keeps a project on the local dev server only, exactly like blog posts.
+
 ## Contributing
 
 I welcome contributions and feedback from the community. If you find any issues or have suggestions for improvements, please feel free to submit a pull request or open an issue.

--- a/src/projects/koszikla-app.md
+++ b/src/projects/koszikla-app.md
@@ -1,0 +1,40 @@
+---
+title: "Kőszikla APP"
+subtitle: "A PWA that keeps a church community scheduled and connected."
+description: "A progressive web app built for my church community: volunteer scheduling with SMS reminders, monthly member pairing, event listings and sermon recordings."
+keywords:
+  - church app
+  - volunteer scheduling
+  - progressive web app
+  - community app
+# TODO: fill in the date this went live
+date: ""
+order: 60
+lang: "en"
+tech:
+  - React
+  - Node.js
+  - PWA
+relatedPosts:
+  - building-koszikla-a-church-app-with-an-ai-sermon-agent
+schemaType: "WebApplication"
+featured: false
+private: false
+---
+
+A web application built for my church community to manage volunteer scheduling and coordination.
+It currently serves around 50 members.
+
+## Features
+
+- Volunteer scheduling, with an SMS notification whenever a member is assigned to a Sunday service
+- A monthly member pairing feature, similar to Slack Donut, that helps people in the community get
+  to know each other
+- Upcoming church events and the recordings that go with them
+- Installable as a progressive web app, so it behaves like a native app on a phone
+
+## What is next
+
+My long-term goal is to open source the app so any church can adopt and customize it. I am also
+building an AI agent that generates concise sermon summaries, identifying key topics and Bible
+verses so sermons become searchable by subject or scripture reference.

--- a/src/projects/mongoose-seed-kit.md
+++ b/src/projects/mongoose-seed-kit.md
@@ -1,0 +1,57 @@
+---
+title: "Mongoose Seed Kit"
+subtitle: "Run Mongoose seed scripts once, and keep track of which ones ran."
+description: "A zero-dependency seeder toolkit for Mongoose that runs seed scripts on startup, records their status in MongoDB, retries failures, and ships a CLI."
+keywords:
+  - mongoose-seed-kit
+  - mongoose seeder
+  - mongodb seeding
+  - database migration
+  - node.js
+date: "2026-03-20"
+updated: "2026-04-28"
+order: 30
+lang: "en"
+github: "https://github.com/kulcsarrudolf/mongoose-seed-kit"
+npm: "https://www.npmjs.com/package/mongoose-seed-kit"
+tech:
+  - Node.js
+  - TypeScript
+  - MongoDB
+schemaType: "SoftwareSourceCode"
+featured: true
+private: false
+---
+
+A seeding toolkit for Mongoose that runs one-time database initialization scripts on application
+startup and records what has already been executed. It exists because every project I worked on
+kept reinventing the same "has this seed already run?" bookkeeping.
+
+## Features
+
+- Runs pending seeders on startup and tracks each result in MongoDB
+- Retries failed seeders on the next run, leaving successful ones alone
+- CLI to scaffold, run, inspect and reset seeders
+- Programmatic API (`runPendingSeeders`, `runSeederByName`, `getSeederStatuses`, `resetSeeder`)
+  for building admin routes
+- Environment aware path resolution, so `src` and `dist` both work
+- Zero external dependencies, no extra model registration
+
+## Install
+
+```bash
+npm install mongoose-seed-kit
+```
+
+```bash
+npx mongoose-seed-kit create add-default-roles
+npx mongoose-seed-kit status
+npx mongoose-seed-kit run
+```
+
+Requires Mongoose 6 or newer.
+
+## Links
+
+Source on [GitHub](https://github.com/kulcsarrudolf/mongoose-seed-kit), package on
+[npm](https://www.npmjs.com/package/mongoose-seed-kit).

--- a/src/projects/puncto-for-video.md
+++ b/src/projects/puncto-for-video.md
@@ -1,0 +1,35 @@
+---
+title: "Puncto for Video"
+subtitle: "Measure the time between two points in a video, down to the millisecond."
+description: "A fully client-side browser tool for precise video timing: mark two points, get the delta instantly, log measurements and export them to CSV."
+keywords:
+  - video timing tool
+  - millisecond timer
+  - frame timing
+  - puncto
+# TODO: fill in the date this went live
+date: ""
+order: 70
+lang: "en"
+website: "https://puncto.live"
+tech:
+  - TypeScript
+  - Browser
+schemaType: "WebApplication"
+featured: false
+private: false
+---
+
+A browser based tool for precise video timing. Mark two points and get the delta instantly, down
+to the millisecond.
+
+## Features
+
+- Two-point measurement with millisecond precision
+- Measurement log, so you can compare several intervals side by side
+- CSV export of everything you have measured
+- Fully client side, so no video and no data ever leaves your device
+
+## Links
+
+Try it at [puncto.live](https://puncto.live).

--- a/src/projects/puncto-timer.md
+++ b/src/projects/puncto-timer.md
@@ -1,0 +1,36 @@
+---
+title: "Puncto Timer"
+subtitle: "A Chrome extension that times any two browser interactions."
+description: "A Chrome extension for measuring elapsed time between any two interactions on any webpage, down to the millisecond."
+keywords:
+  - chrome extension
+  - browser timer
+  - millisecond timer
+  - performance measurement
+  - puncto
+# TODO: fill in the date this went live
+date: ""
+order: 80
+lang: "en"
+website: "https://puncto.live/extension/"
+tech:
+  - TypeScript
+  - Chrome Extension
+schemaType: "WebApplication"
+featured: false
+private: false
+---
+
+A Chrome extension for measuring the elapsed time between any two browser interactions, down to
+the millisecond. It works on any webpage, which makes it handy for checking how long a page really
+takes to react to a click.
+
+## Features
+
+- Start and stop on any two interactions, on any page
+- Millisecond precision
+- No setup per site, install it once and it works everywhere
+
+## Links
+
+Get it at [puncto.live/extension](https://puncto.live/extension/).

--- a/src/projects/samsung-device-helper.md
+++ b/src/projects/samsung-device-helper.md
@@ -1,0 +1,56 @@
+---
+title: "Samsung Device Helper"
+subtitle: "Look up Samsung phones, tablets and watches by model number."
+description: "A zero-dependency Node.js package that resolves Samsung model numbers to device names and returns categorized device lists, kept current by an AI agent."
+keywords:
+  - samsung-device-helper
+  - samsung model number
+  - device lookup
+  - node.js
+  - npm package
+date: "2024-07-18"
+updated: "2026-07-23"
+order: 20
+lang: "en"
+github: "https://github.com/kulcsarrudolf/samsung-device-helper"
+npm: "https://www.npmjs.com/package/samsung-device-helper"
+tech:
+  - Node.js
+  - TypeScript
+relatedPosts:
+  - my-first-open-source-project
+schemaType: "SoftwareSourceCode"
+featured: true
+private: false
+---
+
+A Node.js package that turns a Samsung model number into a human readable device name, and returns
+categorized lists of phones, tablets and watches. It was my first open source project and it is
+still the one people install most often.
+
+## Features
+
+- `getNameByModel(model)` resolves a model number to a device name
+- `getAllSamsungPhones()`, `getAllSamsungTablets()` and `getAllSamsungWatches()` return full lists
+- `getAllSamsungDevices()` returns everything across categories
+- Phone catalogue covers models released from 2017 onwards
+- Subpath imports so you only bundle the category you need
+
+## Install
+
+```bash
+npm install samsung-device-helper
+```
+
+## Keeping the catalogue current
+
+The catalogue is maintained by a companion
+[AI agent](https://github.com/kulcsarrudolf/samsung-device-helper-agent) that uses Playwright MCP
+and Claude. It reads the current year's device file from GitHub, scrapes GSM Arena for new
+releases, sorts them by release date, and opens a pull request automatically whenever the
+catalogue has fallen behind.
+
+## Links
+
+Source on [GitHub](https://github.com/kulcsarrudolf/samsung-device-helper), package on
+[npm](https://www.npmjs.com/package/samsung-device-helper).

--- a/src/projects/template/template-project.md
+++ b/src/projects/template/template-project.md
@@ -1,0 +1,44 @@
+---
+# Required
+title: "Project Name"
+subtitle: "One sentence that fits on a card."
+order: 100 # lower numbers appear first on /projects
+
+# Recommended for SEO
+description: "Up to 160 characters, used as the meta description and in llms.txt."
+keywords:
+  - keyword one
+  - keyword two
+
+# Optional
+date: "" # first public release, YYYY-MM-DD
+updated: "" # last meaningful change, defaults to date
+lang: "en" # "en" or "hu"
+github: ""
+npm: ""
+website: ""
+tech:
+  - TypeScript
+relatedPosts: [] # blog post slugs; private posts are filtered out automatically
+schemaType: "SoftwareSourceCode" # or "WebApplication" for apps and tools
+featured: false
+private: false # true keeps the project on the dev server only
+---
+
+One or two paragraphs about what the project is and why it exists. Keep it short, this is a
+project page rather than an article.
+
+## Features
+
+- What it does
+- What is notable about how it does it
+
+## Install
+
+```bash
+npm install package-name
+```
+
+## Links
+
+Source on [GitHub](), package on [npm]().

--- a/src/projects/zimme-zoom.md
+++ b/src/projects/zimme-zoom.md
@@ -1,0 +1,51 @@
+---
+title: "zimme-zoom"
+subtitle: "React components for viewing, zooming and browsing images."
+description: "zimme-zoom is a dependency-light React library with a zoomable photo viewer, a virtualized media grid, a gallery and a swipeable carousel."
+keywords:
+  - zimme-zoom
+  - react image viewer
+  - react photo viewer
+  - image zoom
+  - react gallery
+  - react carousel
+date: "2025-12-02"
+updated: "2026-04-18"
+order: 10
+lang: "en"
+github: "https://github.com/kulcsarrudolf/zimme-zoom"
+npm: "https://www.npmjs.com/package/zimme-zoom"
+website: "https://zimme-zoom.vercel.app"
+tech:
+  - React
+  - TypeScript
+schemaType: "SoftwareSourceCode"
+featured: true
+private: false
+---
+
+A collection of image related React components published as a single npm package. It started
+because I wanted a photo viewer that felt right on touch devices without pulling in a heavy
+dependency tree, and it now powers the images on this website.
+
+## Features
+
+- `PhotoViewer`: modal viewer with zoom, rotation, navigation, blurred backgrounds and SVG overlays
+- `MediaGrid`: virtualized, month grouped grid with search, jump to month and infinite loading
+- `Gallery`: grid based gallery that hands off to `PhotoViewer`
+- `ImageCarousel`: swipeable carousel with lazy loading and gesture support
+- `Image`: standalone image with loading state and fade in transition
+- Keyboard shortcuts and accessibility support throughout
+- No virtualization dependency, React only
+
+## Install
+
+```bash
+yarn add zimme-zoom
+```
+
+## Links
+
+Source on [GitHub](https://github.com/kulcsarrudolf/zimme-zoom), package on
+[npm](https://www.npmjs.com/package/zimme-zoom), live demo at
+[zimme-zoom.vercel.app](https://zimme-zoom.vercel.app).

--- a/src/types/project.type.ts
+++ b/src/types/project.type.ts
@@ -1,0 +1,21 @@
+export interface Project {
+  title: string;
+  subtitle: string;
+  slug: string;
+  order: number;
+  lang: "hu" | "en";
+  schemaType: "SoftwareSourceCode" | "WebApplication";
+  date?: string;
+  updated?: string;
+  description?: string;
+  keywords?: string[];
+  github?: string;
+  npm?: string;
+  website?: string;
+  tech?: string[];
+  relatedPosts?: string[];
+  featured?: boolean;
+  private?: boolean;
+}
+
+export default Project;

--- a/src/utils/getProjectMetadata.ts
+++ b/src/utils/getProjectMetadata.ts
@@ -1,0 +1,101 @@
+import fs from "fs";
+
+import matter from "gray-matter";
+
+import Project from "@/types/project.type";
+
+const PROJECTS_FOLDER = "./src/projects";
+
+const DEFAULT_ORDER = 100;
+
+// Draft projects (private: true) are visible on the local dev server so they
+// can be previewed, but stay hidden in the production build.
+export const shouldShowPrivateProjects = (): boolean =>
+  process.env.NODE_ENV === "development";
+
+// Frontmatter list fields accept either a YAML list or a comma separated string.
+const toStringArray = (value: unknown): string[] | undefined => {
+  if (Array.isArray(value)) {
+    return value.map((item) => String(item).trim());
+  }
+
+  if (typeof value === "string" && value.trim() !== "") {
+    return value.split(",").map((item) => item.trim());
+  }
+
+  return undefined;
+};
+
+const toProject = (
+  fileName: string,
+  data: matter.GrayMatterFile<string>["data"]
+): Project => ({
+  title: data.title,
+  subtitle: data.subtitle,
+  slug: fileName.replace(".md", ""),
+  order: typeof data.order === "number" ? data.order : DEFAULT_ORDER,
+  lang: data.lang === "hu" ? "hu" : "en",
+  schemaType:
+    data.schemaType === "WebApplication"
+      ? "WebApplication"
+      : "SoftwareSourceCode",
+  date: data.date || undefined,
+  updated: data.updated || undefined,
+  description: data.description,
+  keywords: toStringArray(data.keywords),
+  github: data.github || undefined,
+  npm: data.npm || undefined,
+  website: data.website || undefined,
+  tech: toStringArray(data.tech),
+  relatedPosts: toStringArray(data.relatedPosts),
+  featured: data.featured === true,
+  private: data.private === true,
+});
+
+// The projects list is a curated ordering rather than a chronological feed:
+// `order` ascending, newest first when two projects tie.
+const byOrderThenDate = (a: Project, b: Project): number => {
+  if (a.order !== b.order) {
+    return a.order - b.order;
+  }
+
+  return (b.date || "").localeCompare(a.date || "");
+};
+
+// Returned already sorted, so callers never have to re-sort.
+export const getProjectMetadata = (): Project[] => {
+  const files = fs.readdirSync(PROJECTS_FOLDER);
+
+  const markdownProjects = files.filter((file: string) => file.endsWith(".md"));
+
+  const projects = markdownProjects.map((fileName) => {
+    const fileContents = fs.readFileSync(
+      `${PROJECTS_FOLDER}/${fileName}`,
+      "utf8"
+    );
+
+    return toProject(fileName, matter(fileContents).data);
+  });
+
+  const visibleProjects = shouldShowPrivateProjects()
+    ? projects
+    : projects.filter((project) => !project.private);
+
+  return visibleProjects.sort(byOrderThenDate);
+};
+
+// Only slugs of published projects resolve, which also rejects private
+// projects in production and any path-traversal attempt.
+export const getProjectBySlug = (slug: string): Project | undefined =>
+  getProjectMetadata().find((project) => project.slug === slug);
+
+// Returns null rather than throwing, so an unknown slug can render a 404.
+export const getProjectContent = (slug: string) => {
+  const file = `${PROJECTS_FOLDER}/${slug}.md`;
+
+  if (!getProjectBySlug(slug) || !fs.existsSync(file)) {
+    return null;
+  }
+
+  return matter(fs.readFileSync(file, "utf8"));
+};


### PR DESCRIPTION
## Summary

PR 1 of 5 in the series that turns `/projects` into a markdown-driven system with a page per project. This one is the data layer only: no routes change, no UI changes, and the rendered site is identical after merging.

It mirrors how blog posts already work (`src/posts/` + `getPostMetadata.ts`), so adding a project becomes "drop one markdown file in `src/projects/`".

## Changes

- Add `src/projects/*.md` for the six existing projects, with a template in `src/projects/template/`
- Add `src/types/project.type.ts` and `src/utils/getProjectMetadata.ts`, mirroring the blog equivalents
- Reader exposes `getProjectMetadata`, `getProjectBySlug` and `getProjectContent`, the latter two for the detail route in PR 2
- Sorting and list-field normalisation happen once in the reader, instead of being repeated in every consumer the way the blog code does it
- `getProjectContent` guards with `existsSync` and returns `null`, so an unknown slug can render a 404 rather than throwing
- Document the workflow in the README

## Follow-up needed before this ships publicly

Three projects have no date yet and are marked `# TODO` in their frontmatter: `koszikla-app.md`, `puncto-for-video.md`, `puncto-timer.md`. The field is optional, so nothing breaks, but they will have no `datePublished` in structured data until filled in.

## Verification

- `yarn lint`: no warnings or errors
- `yarn build`: passes, route output unchanged
- Frontmatter parse check: all 6 top-level files parse, the `template/` subfolder is correctly excluded, dates read back as strings