### PR TITLE
feat: render the projects list from markdown

### DIFF
--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,6 +1,9 @@
 import { Suspense } from "react";
 import type { Metadata } from "next";
+
 import ProjectsPage from "@/pages/ProjectsPage";
+import { SITE_URL } from "@/config/site";
+import { getProjectMetadata } from "@/utils/getProjectMetadata";
 
 const PROJECTS_TITLE = "Projects";
 const PROJECTS_DESCRIPTION =
@@ -16,6 +19,7 @@ const PROJECTS_KEYWORDS = [
   "puncto",
   "samsung-device-helper",
   "zimme-zoom",
+  "mongoose-seed-kit",
 ];
 
 export const metadata: Metadata = {
@@ -27,7 +31,7 @@ export const metadata: Metadata = {
   },
   openGraph: {
     type: "website",
-    url: "https://kulcsarrudolf.com/projects",
+    url: `${SITE_URL}/projects`,
     title: `${PROJECTS_TITLE} | Kulcsar Rudolf`,
     description: PROJECTS_DESCRIPTION,
   },
@@ -39,10 +43,32 @@ export const metadata: Metadata = {
 };
 
 const Projects = () => {
+  const projects = getProjectMetadata();
+
+  // Built on the server, so the list costs nothing on the client.
+  const structuredData = {
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    name: PROJECTS_TITLE,
+    description: PROJECTS_DESCRIPTION,
+    itemListElement: projects.map((project, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      name: project.title,
+      url: `${SITE_URL}/projects/${project.slug}`,
+    })),
+  };
+
   return (
-    <Suspense fallback={<div>Loading...</div>}>
-      <ProjectsPage />
-    </Suspense>
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+      />
+      <Suspense fallback={<div>Loading...</div>}>
+        <ProjectsPage projects={projects} />
+      </Suspense>
+    </>
   );
 };
 

--- a/src/components/projects/ProjectCard.tsx
+++ b/src/components/projects/ProjectCard.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import NextLink from "next/link";
+
+import { useTranslation } from "@/i18n/useTranslation";
+import Project from "@/types/project.type";
+
+type ProjectCardProps = {
+  project: Project;
+};
+
+// The card links only to the project page. GitHub and npm links live there,
+// so every click from this list lands on the page we want indexed.
+const ProjectCard = ({ project }: ProjectCardProps) => {
+  const { t } = useTranslation();
+  const languageLabel = project.lang === "hu" ? "[HU]" : "";
+  const href = `/projects/${project.slug}`;
+
+  return (
+    <div className="bg-white border border-gray-200 rounded-xl p-5 shadow-sm hover:shadow-md transition-shadow">
+      <h2 className="text-lg font-semibold mb-2">
+        <NextLink
+          href={href}
+          className="hover:underline"
+          style={{ color: "#4267b2" }}
+        >
+          <span className="text-blue-900">{languageLabel}</span>
+          {project.title}
+        </NextLink>
+      </h2>
+      <p className="text-gray-600 text-sm leading-relaxed">
+        {project.subtitle}
+      </p>
+      {project.tech?.length ? (
+        <div className="flex flex-wrap gap-2 mt-3">
+          {project.tech.map((tech) => (
+            <span
+              key={tech}
+              className="text-xs text-gray-600 bg-gray-100 border border-gray-200 rounded-full px-2 py-0.5"
+            >
+              {tech}
+            </span>
+          ))}
+        </div>
+      ) : null}
+      <div className="mt-4">
+        <NextLink
+          href={href}
+          className="text-sm hover:underline"
+          style={{ color: "#4267b2" }}
+        >
+          {t("projects.viewProject")}
+        </NextLink>
+      </div>
+    </div>
+  );
+};
+
+export default ProjectCard;

--- a/src/i18n/translations/en.json
+++ b/src/i18n/translations/en.json
@@ -40,6 +40,13 @@
     "title": "My Blog",
     "articles": "Articles"
   },
+  "projects": {
+    "title": "Projects",
+    "description": "A selection of things I've built: side projects, open-source packages, and tools I use myself.",
+    "viewProject": "View project →",
+    "moreOnGitHub": "Want to see more? {githubLink}",
+    "findOnGitHub": "Find more on my GitHub"
+  },
   "contact": {
     "title": "Get In Touch",
     "description": "I'm always open to discussing new opportunities, interesting projects, or technical collaborations. Whether you're looking for a senior full-stack engineer or just want to connect, feel free to reach out.",

--- a/src/i18n/translations/hu.json
+++ b/src/i18n/translations/hu.json
@@ -40,6 +40,13 @@
     "title": "Blog",
     "articles": "Cikkek"
   },
+  "projects": {
+    "title": "Projektek",
+    "description": "Néhány dolog, amit építettem: mellékprojektek, nyílt forráskódú csomagok és eszközök, amelyeket magam is használok.",
+    "viewProject": "Projekt megtekintése →",
+    "moreOnGitHub": "Kíváncsi vagy többre? {githubLink}",
+    "findOnGitHub": "Nézd meg a GitHub oldalamat"
+  },
   "contact": {
     "title": "Kapcsolat",
     "description": "Szívesen beszélgetek új lehetőségekről, izgalmas projektekről vagy technikai kollaborációkról. Ha senior full-stack fejlesztőt keresel, vagy csak szeretnél csevegni, keress bátran!",

--- a/src/pages/ProjectsPage.tsx
+++ b/src/pages/ProjectsPage.tsx
@@ -2,99 +2,35 @@
 
 import { Title } from "@/components/general/typography";
 import Link from "@/components/general/typography/Link";
+import ProjectCard from "@/components/projects/ProjectCard";
+import { useTranslation } from "@/i18n/useTranslation";
+import Project from "@/types/project.type";
 
-const personalProjects = [
-  {
-    name: "zimme-zoom",
-    description:
-      "A collection of image-related React components packaged as an npm package. The main component is PhotoViewer, a lightweight React photo viewer with zoom, navigation, blurred background, and SVG overlay support.",
-    repo: "https://github.com/kulcsarrudolf/zimme-zoom",
-  },
-  {
-    name: "Samsung Device Helper",
-    description:
-      "A Node.js package published on npm that provides utilities and helpers for working with Samsung devices, simplifying common device management tasks.",
-    secondaryDescription:
-      "Also includes an AI agent that uses Playwright MCP and Claude to keep the device catalogue up to date. It reads the current year's device file from GitHub, scrapes GSM Arena for new releases, sorts them by release date, and opens a GitHub pull request automatically if the catalogue is out of date.",
-    secondaryLink: {
-      text: "AI agent",
-      url: "https://github.com/kulcsarrudolf/samsung-device-helper-agent",
-    },
-    repo: "https://www.npmjs.com/package/samsung-device-helper",
-  },
-  {
-    name: "Kőszikla APP (PWA)",
-    description:
-      "Web application developed for my church community to manage volunteer scheduling and coordination. The app sends SMS notifications whenever a member is assigned to a service on Sunday. It includes a feature similar to Slack Donut that helps members connect with one another each month, fostering stronger relationships within the community. In addition, Koszikla provides access to upcoming church events and related recordings. The platform currently serves around 50 members. My long-term goal is to make this app open-source so that any church can adopt and customize it for their own community. I'm also developing an AI agent that automatically generates concise summaries of sermons, identifying key topics and Bible verses to make it easier to search and explore sermons by subject or scripture reference.",
-    repo: null,
-  },
-  {
-    name: "Puncto for Video",
-    description:
-      "Browser-based tool for precise video timing. Mark two points and get the delta instantly, down to the millisecond. Features measurement logging, CSV export, and interval comparison. Fully client-side, so no data leaves the device.",
-    repo: "https://puncto.live",
-  },
-  {
-    name: "Puncto Timer",
-    description:
-      "Chrome Extension for measuring elapsed time between any two browser interactions, down to the millisecond. Works on any webpage.",
-    repo: "https://puncto.live/extension/",
-  },
-  {
-    name: "Mongoose Seed Kit",
-    description:
-      "A lightweight seeder toolkit for Mongoose that runs seed scripts on application startup and tracks their execution status. Supports one-time execution, automatic retries for failed seeds, a CLI for generating new seeders, and helper functions for building admin routes. Zero external dependencies.",
-    repo: "https://www.npmjs.com/package/mongoose-seed-kit",
-  },
-];
-
-type Project = (typeof personalProjects)[number];
-
-function ProjectCard({ project }: { project: Project }) {
-  return (
-    <div className="bg-white border border-gray-200 rounded-xl p-5 shadow-sm hover:shadow-md transition-shadow">
-      <div className="flex items-start justify-between gap-3 mb-2">
-        <h2 className="text-lg font-semibold" style={{ color: "#4267b2" }}>
-          {project.name}
-        </h2>
-        {project.repo && <Link href={project.repo}>Visit</Link>}
-      </div>
-      <p className="text-gray-600 text-sm leading-relaxed">
-        {project.description}
-      </p>
-      {"secondaryDescription" in project && project.secondaryDescription && (
-        <p className="text-gray-600 text-sm leading-relaxed mt-2">
-          {project.secondaryDescription}{" "}
-          {"secondaryLink" in project && project.secondaryLink && (
-            <Link href={project.secondaryLink.url}>
-              {project.secondaryLink.text}
-            </Link>
-          )}
-        </p>
-      )}
-    </div>
-  );
+interface ProjectsPageProps {
+  projects: Project[];
 }
 
-export default function ProjectsPage() {
+export default function ProjectsPage({ projects }: ProjectsPageProps) {
+  const { t } = useTranslation();
+
   return (
     <>
-      <Title>Projects</Title>
-      <p className="text-gray-600 mb-6">
-        A selection of things I&apos;ve built — side projects, open-source
-        packages, and tools I use myself.
-      </p>
+      <Title>{t("projects.title")}</Title>
+      <p className="text-gray-600 mb-6">{t("projects.description")}</p>
       <div className="flex flex-col gap-4">
-        {personalProjects.map((project) => (
-          <ProjectCard key={project.name} project={project} />
+        {(projects || []).map((project) => (
+          <ProjectCard key={project.slug} project={project} />
         ))}
       </div>
       <div className="mt-8 pt-6 border-t border-gray-200 text-center">
         <p className="text-gray-600 text-sm">
-          Want to see more?{" "}
-          <Link href="https://github.com/kulcsarrudolf">
-            Find more on my GitHub
-          </Link>
+          {t("projects.moreOnGitHub", {
+            githubLink: (
+              <Link href="https://github.com/kulcsarrudolf">
+                {t("projects.findOnGitHub")}
+              </Link>
+            ),
+          })}
         </p>
       </div>
     </>


### PR DESCRIPTION
## Summary

PR 3 of 5. `/projects` now renders from the markdown files instead of the hardcoded array, and every card links to the project page added in #54. This is the visible switch in the series.

## Changes

- `src/app/projects/page.tsx` loads projects on the server and passes them down, mirroring how `blog/page.tsx` feeds `BlogPage`
- Add `ProjectCard`: title, one-line subtitle, tech chips and a link to the project page
- GitHub and npm links intentionally live on the project page only. Every click from this list now lands on the page we want indexed, rather than bouncing straight to GitHub
- Emit `ItemList` JSON-LD from the server component, so it costs nothing on the client
- Add `projects.*` keys to `en.json` and `hu.json`. The page chrome was hardcoded English while the site has an EN/HU switcher
- Add `mongoose-seed-kit` to the page keywords

`ProjectsPage` keeps the `projects || []` guard that `BlogPage` already uses, because `src/pages/` is an active Pages Router and prerenders these view components without props.

## Verification

- `yarn lint` clean, `yarn build` clean, `/projects` still static
- All 6 cards render in the curated `order` sequence: zimme-zoom, Samsung Device Helper, Mongoose Seed Kit, Kőszikla APP, Puncto for Video, Puncto Timer
- `ItemList` JSON-LD lists all 6 in the same order with absolute production URLs
- Clicking a card title navigates to the project page
- `/projects?lang=hu` renders the Hungarian heading, intro, "Projekt megtekintése" CTA and footer line
- No console errors