### PR TITLE
feat: give projects sitemap, llms.txt and markdown parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,16 @@ Frontmatter worth knowing about:
   safe to reference a draft.
 - `private: true` keeps a project on the local dev server only, exactly like blog posts.
 
+## Markdown for AI Agents
+
+Every blog post and project page is also served as clean markdown, so agents and LLM tooling can
+read the content without parsing HTML. Two ways to get it:
+
+- Append `.md` to the URL: `https://kulcsarrudolf.com/projects/pg-seed-kit.md`
+- Request the normal URL with an `Accept: text/markdown` header
+
+`/llms.txt` lists every post and project with a summary and a link to its markdown version.
+
 ## Contributing
 
 I welcome contributions and feedback from the community. If you find any issues or have suggestions for improvements, please feel free to submit a pull request or open an issue.

--- a/src/app/llms.txt/route.ts
+++ b/src/app/llms.txt/route.ts
@@ -1,5 +1,11 @@
 import { getPostMetadata } from "@/utils/getPostMetadata";
-import { AUTHOR_NAME, SITE_NAME, SITE_URL, SOCIAL_PROFILES } from "@/config/site";
+import { getProjectMetadata } from "@/utils/getProjectMetadata";
+import {
+  AUTHOR_NAME,
+  SITE_NAME,
+  SITE_URL,
+  SOCIAL_PROFILES,
+} from "@/config/site";
 
 export const dynamic = "force-static";
 
@@ -13,16 +19,25 @@ export function GET() {
     return `- [${post.title}](${SITE_URL}/posts/${post.slug}.md): ${summary}`;
   });
 
+  const projectLines = getProjectMetadata().map((project) => {
+    const summary = project.description || project.subtitle;
+    return `- [${project.title}](${SITE_URL}/projects/${project.slug}.md): ${summary}`;
+  });
+
   const body = [
     `# ${SITE_NAME}`,
     "",
     `> Personal website and blog of ${AUTHOR_NAME}, a full-stack software developer. Articles about software development, side projects, and the tools and ideas he works with every day.`,
     "",
-    "Every blog post is available as clean markdown: append `.md` to the post URL, or request the post URL with an `Accept: text/markdown` header.",
+    "Every blog post and project page is available as clean markdown: append `.md` to the URL, or request the URL with an `Accept: text/markdown` header.",
     "",
     "## Blog",
     "",
     ...postLines,
+    "",
+    "## Projects",
+    "",
+    ...projectLines,
     "",
     "## Pages",
     "",

--- a/src/app/markdown/projects/[slug]/route.ts
+++ b/src/app/markdown/projects/[slug]/route.ts
@@ -1,0 +1,55 @@
+import {
+  getProjectBySlug,
+  getProjectContent,
+  getProjectMetadata,
+} from "@/utils/getProjectMetadata";
+import { SITE_URL } from "@/config/site";
+
+export const dynamic = "force-static";
+
+export const generateStaticParams = () => {
+  return getProjectMetadata().map((project) => ({ slug: project.slug }));
+};
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ slug: string }> }
+) {
+  const { slug } = await params;
+
+  // Only slugs of published projects are served; this also rejects
+  // private projects and any path-traversal attempts.
+  const project = getProjectBySlug(slug);
+  const file = getProjectContent(slug);
+
+  if (!project || !file) {
+    return new Response("Not found", { status: 404 });
+  }
+
+  // The fact lines are the point of this route: they turn a prose page
+  // into something an agent can read without parsing the body.
+  const facts = [
+    `Canonical URL: ${SITE_URL}/projects/${slug}`,
+    ...(project.github ? [`GitHub: ${project.github}`] : []),
+    ...(project.npm ? [`npm: ${project.npm}`] : []),
+    ...(project.website ? [`Website: ${project.website}`] : []),
+    ...(project.tech?.length ? [`Tech: ${project.tech.join(", ")}`] : []),
+    ...(project.date ? [`Published: ${project.date}`] : []),
+  ];
+
+  const body = [
+    `# ${project.title}`,
+    "",
+    ...(project.subtitle ? [`> ${project.subtitle}`, ""] : []),
+    ...facts,
+    "",
+    file.content.trim(),
+    "",
+  ].join("\n");
+
+  return new Response(body, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+    },
+  });
+}

--- a/src/app/posts/[slug]/page.tsx
+++ b/src/app/posts/[slug]/page.tsx
@@ -10,6 +10,7 @@ import { Title, Subtitle } from "@/components/general/typography";
 
 import { getPostMetadata, shouldShowPrivatePosts } from "@/utils/getPostMetadata";
 import PostedOn from "@/components/general/PostedOn";
+import { SITE_URL } from "@/config/site";
 
 const getPostContent = (slug: string) => {
   const folder = "./src/posts";
@@ -30,16 +31,6 @@ export const generateStaticParams = () => {
 
 type Params = Promise<{ slug: string }>;
 
-const getBaseUrl = () => {
-  if (process.env.NEXT_PUBLIC_BASE_URL) {
-    return process.env.NEXT_PUBLIC_BASE_URL;
-  }
-  if (process.env.VERCEL_URL) {
-    return `https://${process.env.VERCEL_URL}`;
-  }
-  return "https://kulcsarrudolf.com";
-};
-
 export async function generateMetadata({
   params,
 }: {
@@ -47,8 +38,7 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { slug } = await params;
   const post = getPostContent(slug);
-  const baseUrl = getBaseUrl();
-  const url = `${baseUrl}/posts/${slug}`;
+  const url = `${SITE_URL}/posts/${slug}`;
 
   const title = post.data.title;
   const fullTitle = `${title} | Kulcsar Rudolf`;
@@ -85,7 +75,7 @@ export async function generateMetadata({
       creator: "@kulcsarrudolf",
     },
     alternates: {
-      canonical: url,
+      canonical: `/posts/${slug}`,
     },
   };
 }
@@ -98,8 +88,7 @@ const PostPage = async ({ params }: { params: Params }) => {
     notFound();
   }
 
-  const baseUrl = getBaseUrl();
-  const url = `${baseUrl}/posts/${slug}`;
+  const url = `${SITE_URL}/posts/${slug}`;
   const description =
     post.data.description ||
     post.data.subtitle ||
@@ -111,18 +100,18 @@ const PostPage = async ({ params }: { params: Params }) => {
     "@type": "BlogPosting",
     headline: post.data.title,
     description: description,
-    image: `${baseUrl}/images/me-logo.png`,
+    image: `${SITE_URL}/images/me-logo.png`,
     datePublished: post.data.date,
     dateModified: post.data.date,
     author: {
       "@type": "Person",
       name: post.data.author,
-      url: baseUrl,
+      url: SITE_URL,
     },
     publisher: {
       "@type": "Person",
       name: post.data.author,
-      url: baseUrl,
+      url: SITE_URL,
     },
     mainEntityOfPage: {
       "@type": "WebPage",

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,6 +1,7 @@
 import type { MetadataRoute } from "next";
 
 import { getPostMetadata } from "@/utils/getPostMetadata";
+import { getProjectMetadata } from "@/utils/getProjectMetadata";
 import { SITE_URL } from "@/config/site";
 
 export default function sitemap(): MetadataRoute.Sitemap {
@@ -19,5 +20,18 @@ export default function sitemap(): MetadataRoute.Sitemap {
     lastModified: new Date(post.date),
   }));
 
-  return [...pages, ...posts];
+  // `date` is optional on projects, so only send lastModified when we
+  // actually have one. An Invalid Date would break the generated XML.
+  const projects: MetadataRoute.Sitemap = getProjectMetadata().map(
+    (project) => {
+      const changedAt = project.updated || project.date;
+
+      return {
+        url: `${SITE_URL}/projects/${project.slug}`,
+        ...(changedAt ? { lastModified: new Date(changedAt) } : {}),
+      };
+    }
+  );
+
+  return [...pages, ...posts, ...projects];
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,25 +1,26 @@
 import { NextRequest, NextResponse } from "next/server";
 
-// Serves blog posts as clean markdown for AI agents:
-// - /posts/<slug>.md always returns markdown
-// - /posts/<slug> returns markdown when the client asks for it
-//   via an Accept: text/markdown header
+// Serves blog posts and project pages as clean markdown for AI agents:
+// - /posts/<slug>.md and /projects/<slug>.md always return markdown
+// - /posts/<slug> and /projects/<slug> return markdown when the client
+//   asks for it via an Accept: text/markdown header
 export function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
-  const mdExtensionMatch = pathname.match(/^\/posts\/([^/]+)\.md$/);
+  const mdExtensionMatch = pathname.match(/^\/(posts|projects)\/([^/]+)\.md$/);
   if (mdExtensionMatch) {
     const url = request.nextUrl.clone();
-    url.pathname = `/markdown/posts/${mdExtensionMatch[1]}`;
+    url.pathname = `/markdown/${mdExtensionMatch[1]}/${mdExtensionMatch[2]}`;
     return NextResponse.rewrite(url);
   }
 
-  const postMatch = pathname.match(/^\/posts\/([^/]+)$/);
+  const pageMatch = pathname.match(/^\/(posts|projects)\/([^/]+)$/);
   const accept = request.headers.get("accept") ?? "";
-  if (postMatch && accept.includes("text/markdown")) {
+  if (pageMatch && accept.includes("text/markdown")) {
     const url = request.nextUrl.clone();
-    url.pathname = `/markdown/posts/${postMatch[1]}`;
+    url.pathname = `/markdown/${pageMatch[1]}/${pageMatch[2]}`;
     const response = NextResponse.rewrite(url);
+    // Without this a CDN can serve the markdown response to HTML clients.
     response.headers.set("Vary", "Accept");
     return response;
   }
@@ -27,6 +28,7 @@ export function middleware(request: NextRequest) {
   return NextResponse.next();
 }
 
+// `:slug+` rather than `:slug*` so /projects itself does not invoke this.
 export const config = {
-  matcher: ["/posts/:slug*"],
+  matcher: ["/posts/:slug*", "/projects/:slug+"],
 };


### PR DESCRIPTION
## Summary

PR 4 of 5. The project pages existed but were invisible to crawlers and AI agents. This gives them the same surface blog posts already have: sitemap entries, an `llms.txt` listing, and a raw-markdown route served through content negotiation. No visual change.

## Changes

- `sitemap.ts`: add project URLs, using `updated || date` for `lastModified` and omitting it when a project has neither. `date` is optional, and `new Date(undefined)` would emit an Invalid Date into the XML
- `llms.txt`: add a `## Projects` section and widen the markdown sentence to cover both sections
- Add `/markdown/projects/<slug>`, mirroring the posts route. It emits canonical URL, GitHub, npm, website, tech and published date as fact lines above the body, so an agent gets a machine-readable fact sheet rather than only prose
- `middleware.ts`: one regex pair covering both sections, with `:slug+` for projects so `/projects` itself does not invoke the middleware. `Vary: Accept` retained
- Replace the page-local `getBaseUrl()` in `src/app/posts/[slug]/page.tsx` with `SITE_URL`, and make the canonical relative. All SEO surfaces now agree. Preview deploys emit production canonicals instead of preview-host ones, which is the standard-correct behaviour
- Document the markdown convention in the README

## Verification

- `yarn lint` clean, `yarn build` clean, `/markdown/projects/[slug]` prerenders 6 routes
- `/sitemap.xml` lists all 6 project URLs
- `/llms.txt` has a `## Projects` section with all 6 and their descriptions
- `/projects/zimme-zoom.md` returns `text/markdown` with the full fact block (canonical, GitHub, npm, website, tech, published)
- `curl -H "Accept: text/markdown" /projects/mongoose-seed-kit` returns markdown with `Vary: Accept`; `Accept: text/html` still returns HTML
- `/projects` itself returns HTML, confirming `:slug+` does not swallow the list page
- Blog regression: `/posts/<slug>.md` still returns markdown, and the post canonical now resolves to the production URL