### PR TITLE
feat: add PG Seed Kit and STL Metrics projects

### DIFF
--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -20,6 +20,8 @@ const PROJECTS_KEYWORDS = [
   "samsung-device-helper",
   "zimme-zoom",
   "mongoose-seed-kit",
+  "pg-seed-kit",
+  "stl-metrics",
 ];
 
 export const metadata: Metadata = {

--- a/src/projects/pg-seed-kit.md
+++ b/src/projects/pg-seed-kit.md
@@ -1,0 +1,59 @@
+---
+title: "PG Seed Kit"
+subtitle: "Run Postgres seeds once, whichever ORM you use."
+description: "A zero-dependency Postgres seeder toolkit that tracks which seeds have run and applies each one exactly once, with adapters for Prisma, Drizzle, TypeORM and Sequelize."
+keywords:
+  - pg-seed-kit
+  - postgres seeder
+  - database seeding
+  - prisma
+  - drizzle
+  - typeorm
+  - sequelize
+date: "2026-07-16"
+updated: "2026-07-16"
+order: 40
+lang: "en"
+github: "https://github.com/kulcsarrudolf/pg-seed-kit"
+npm: "https://www.npmjs.com/package/pg-seed-kit"
+website: "https://kulcsarrudolf.github.io/pg-seed-kit/"
+tech:
+  - TypeScript
+  - Node.js
+  - PostgreSQL
+schemaType: "SoftwareSourceCode"
+featured: true
+private: false
+---
+
+A seeder toolkit for Postgres that runs one-time seed scripts on startup and records which ones
+have already been applied, so each seeder runs exactly once. It is the Postgres counterpart to
+[Mongoose Seed Kit](/projects/mongoose-seed-kit), built the same way and for the same reason.
+
+## Features
+
+- Runs pending seeders on startup and tracks each result, creating the tracking table on first run
+- Retries failed seeders on the next run, leaving successful ones untouched
+- Adapters for Prisma, Drizzle, TypeORM and Sequelize, imported as subpaths such as
+  `pg-seed-kit/prisma`
+- Reuses your ORM's existing connection, so there is nothing extra to configure
+- CLI to create, run, inspect and reset seeders
+- Zero runtime dependencies
+
+## Install
+
+```bash
+npm install pg-seed-kit
+```
+
+```bash
+npx pg-seed-kit create add-default-roles
+npx pg-seed-kit status
+npx pg-seed-kit run
+```
+
+## Links
+
+Source on [GitHub](https://github.com/kulcsarrudolf/pg-seed-kit), package on
+[npm](https://www.npmjs.com/package/pg-seed-kit), docs at
+[kulcsarrudolf.github.io/pg-seed-kit](https://kulcsarrudolf.github.io/pg-seed-kit/).

--- a/src/projects/stl-metrics.md
+++ b/src/projects/stl-metrics.md
@@ -1,0 +1,58 @@
+---
+title: "STL Metrics"
+subtitle: "Compute volume, area and watertightness from an STL mesh."
+description: "A zero-dependency library for computing STL mesh metrics: volume, surface area, bounding box, center of mass and watertightness, in the browser and in Node."
+keywords:
+  - stl-metrics
+  - stl volume
+  - 3d mesh metrics
+  - watertight mesh
+  - 3d printing
+  - stl parser
+date: "2026-07-22"
+updated: "2026-07-23"
+order: 50
+lang: "en"
+github: "https://github.com/kulcsarrudolf/stl-metrics"
+npm: "https://www.npmjs.com/package/stl-metrics"
+tech:
+  - TypeScript
+  - Browser
+  - Node.js
+schemaType: "SoftwareSourceCode"
+featured: true
+private: false
+---
+
+A library for measuring STL meshes. Point it at a file and it returns volume, surface area,
+bounding box, center of mass, triangle count and whether the mesh is watertight. It runs in the
+browser as happily as in Node, which makes it useful for 3D printing tools that want to quote a
+price before anything is uploaded to a server.
+
+## Features
+
+- Parses both binary and ASCII STL with a hand-written parser and no dependencies
+- Volume, surface area, bounding box, center of mass, triangle count and watertightness
+- Optional weight estimate from a density and a unit scale
+- Accepts almost any input: `ArrayBuffer`, typed arrays, `Blob` or `File`, streams, or a Node file
+  path
+- Flags non-watertight or degenerate geometry through a `warnings` array instead of failing
+- Optional off-main-thread worker, so a large mesh does not block the UI
+
+## Install
+
+```bash
+npm install stl-metrics
+```
+
+```js
+import { parseStl } from "stl-metrics";
+
+const metrics = await parseStl(file, { worker: true, density: 1.24, unitScale: "mm" });
+console.log(metrics.volume, metrics.isWatertight, metrics.weight);
+```
+
+## Links
+
+Source on [GitHub](https://github.com/kulcsarrudolf/stl-metrics), package on
+[npm](https://www.npmjs.com/package/stl-metrics).


### PR DESCRIPTION
## Summary

PR 5 of 5, the payoff. Two new open source libraries join the site, and adding each one is a single markdown file. No TypeScript or component changes in this diff.

## Changes

- `src/projects/pg-seed-kit.md`: zero-dependency Postgres seeder that applies each seed exactly once, with adapters for Prisma, Drizzle, TypeORM and Sequelize, plus a CLI
- `src/projects/stl-metrics.md`: STL mesh metrics (volume, surface area, bounding box, center of mass, watertightness) for the browser and Node, with an optional off-main-thread worker
- Add both to the `/projects` page keywords

`pg-seed-kit` cross-links to `mongoose-seed-kit`. That stays in-tab, because the markdown renderer only sends non-relative hrefs to a new tab.

## Verification

- `yarn lint` clean, `yarn build` clean
- 8 project pages and 8 markdown routes prerendered
- Both appear on `/projects`, in `sitemap.xml` (8 project URLs) and in `llms.txt` (8 project entries)
- `/projects/pg-seed-kit.md` returns the full fact block: canonical, GitHub, npm, website, tech, published
- `/projects/stl-metrics` renders correctly with no console errors
- Link targets confirmed: the internal cross-link is same-tab, the three external links are `_blank`