### PR TITLE
feat: make project cards easier to scan and click

### DIFF
--- a/src/components/projects/ProjectCard.tsx
+++ b/src/components/projects/ProjectCard.tsx
@@ -1,6 +1,9 @@
 "use client";
 
 import NextLink from "next/link";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faGithub, faNpm } from "@fortawesome/free-brands-svg-icons";
+import { faArrowRight, faGlobe } from "@fortawesome/free-solid-svg-icons";
 
 import { useTranslation } from "@/i18n/useTranslation";
 import Project from "@/types/project.type";
@@ -10,49 +13,75 @@ type ProjectCardProps = {
 };
 
 // The card links only to the project page. GitHub and npm links live there,
-// so every click from this list lands on the page we want indexed.
+// so every click from this list lands on the page we want indexed. The icons
+// in the footer only advertise which of those links a project has.
 const ProjectCard = ({ project }: ProjectCardProps) => {
   const { t } = useTranslation();
   const languageLabel = project.lang === "hu" ? "[HU]" : "";
   const href = `/projects/${project.slug}`;
 
+  const linkIcons = [
+    { key: "github", icon: faGithub, label: "GitHub", has: project.github },
+    { key: "npm", icon: faNpm, label: "npm", has: project.npm },
+    { key: "website", icon: faGlobe, label: "Website", has: project.website },
+  ].filter((link) => Boolean(link.has));
+
   return (
-    <div className="bg-white border border-gray-200 rounded-xl p-5 shadow-sm hover:shadow-md transition-shadow">
-      <h2 className="text-lg font-semibold mb-2">
-        <NextLink
-          href={href}
-          className="hover:underline"
+    <NextLink
+      href={href}
+      className="group flex h-full flex-col rounded-xl border border-gray-200 bg-white p-5 shadow-sm transition duration-200 hover:-translate-y-0.5 hover:border-blue-400 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:ring-offset-2"
+    >
+      {/* The body grows so the footer sits on the same line in every card of a row. */}
+      <div className="flex-1">
+        <h2
+          className="text-lg font-semibold leading-snug group-hover:underline"
           style={{ color: "#4267b2" }}
         >
           <span className="text-blue-900">{languageLabel}</span>
           {project.title}
-        </NextLink>
-      </h2>
-      <p className="text-gray-600 text-sm leading-relaxed">
-        {project.subtitle}
-      </p>
-      {project.tech?.length ? (
-        <div className="flex flex-wrap gap-2 mt-3">
-          {project.tech.map((tech) => (
-            <span
-              key={tech}
-              className="text-xs text-gray-600 bg-gray-100 border border-gray-200 rounded-full px-2 py-0.5"
-            >
-              {tech}
-            </span>
+        </h2>
+
+        <p className="mt-2 text-sm leading-relaxed text-gray-600">
+          {project.subtitle}
+        </p>
+
+        {project.tech?.length ? (
+          <div className="mt-3 flex flex-wrap gap-1.5">
+            {project.tech.map((tech) => (
+              <span
+                key={tech}
+                className="rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-600 ring-1 ring-inset ring-gray-200 transition-colors group-hover:bg-blue-50 group-hover:text-blue-700 group-hover:ring-blue-200"
+              >
+                {tech}
+              </span>
+            ))}
+          </div>
+        ) : null}
+      </div>
+
+      <div className="mt-4 flex items-center justify-between gap-3 border-t border-gray-100 pt-3">
+        <span className="flex items-center gap-3 text-gray-400">
+          {linkIcons.map((link) => (
+            <FontAwesomeIcon
+              key={link.key}
+              icon={link.icon}
+              title={link.label}
+              className="text-base transition-colors group-hover:text-gray-600"
+            />
           ))}
-        </div>
-      ) : null}
-      <div className="mt-4">
-        <NextLink
-          href={href}
-          className="text-sm hover:underline"
+        </span>
+        <span
+          className="flex items-center gap-1.5 text-sm font-medium"
           style={{ color: "#4267b2" }}
         >
           {t("projects.viewProject")}
-        </NextLink>
+          <FontAwesomeIcon
+            icon={faArrowRight}
+            className="text-xs transition-transform duration-200 group-hover:translate-x-1"
+          />
+        </span>
       </div>
-    </div>
+    </NextLink>
   );
 };
 

--- a/src/i18n/translations/en.json
+++ b/src/i18n/translations/en.json
@@ -43,7 +43,7 @@
   "projects": {
     "title": "Projects",
     "description": "A selection of things I've built: side projects, open-source packages, and tools I use myself.",
-    "viewProject": "View project →",
+    "viewProject": "View project",
     "moreOnGitHub": "Want to see more? {githubLink}",
     "findOnGitHub": "Find more on my GitHub"
   },

--- a/src/i18n/translations/hu.json
+++ b/src/i18n/translations/hu.json
@@ -43,7 +43,7 @@
   "projects": {
     "title": "Projektek",
     "description": "Néhány dolog, amit építettem: mellékprojektek, nyílt forráskódú csomagok és eszközök, amelyeket magam is használok.",
-    "viewProject": "Projekt megtekintése →",
+    "viewProject": "Projekt megtekintése",
     "moreOnGitHub": "Kíváncsi vagy többre? {githubLink}",
     "findOnGitHub": "Nézd meg a GitHub oldalamat"
   },

--- a/src/pages/ProjectsPage.tsx
+++ b/src/pages/ProjectsPage.tsx
@@ -17,7 +17,7 @@ export default function ProjectsPage({ projects }: ProjectsPageProps) {
     <>
       <Title>{t("projects.title")}</Title>
       <p className="text-gray-600 mb-6">{t("projects.description")}</p>
-      <div className="flex flex-col gap-4">
+      <div className="grid gap-4 sm:grid-cols-2">
         {(projects || []).map((project) => (
           <ProjectCard key={project.slug} project={project} />
         ))}


### PR DESCRIPTION
## Summary
Redesigns the cards on `/projects` so the list is quicker to scan and each card is obviously clickable. The whole card is now the link, and the list uses a two-column grid instead of one tall stack.

## Changes
- The entire card is a single link, with a hover lift, blue border, deeper shadow, underlined title and sliding arrow
- Added a `focus-visible` ring so keyboard navigation is visible (there was none)
- Two-column responsive grid on `sm` and up, with equal-height cards so footers line up across a row
- Footer separated by a hairline rule: GitHub / npm / website icons on the left showing what each project offers, "View project" on the right
- Tech chips pick up a subtle blue tint on card hover
- Removed the literal arrow from the `projects.viewProject` strings in both locales, now that it renders as an animated icon