### PR TITLE
feat: make project page nav links easier to hit

### DIFF
--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -134,9 +134,24 @@ const ProjectPage = async ({ params }: { params: Params }) => {
         <div className="mt-8 pt-6 border-t border-gray-200">
           <NextLink
             href="/projects"
-            className="text-sm hover:underline"
+            // Negative margin cancels the padding so the arrow sits on the
+            // body text's left edge, matching the related-posts links, while
+            // the padded hit area stays comfortably large.
+            className="group -ml-3 inline-flex items-start gap-2 rounded-md px-3 py-3 text-sm font-medium transition-colors hover:bg-gray-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#4267b2]"
             style={{ color: "#4267b2" }}
           >
+            <svg
+              aria-hidden="true"
+              viewBox="0 0 16 16"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={1.75}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className="mt-[3px] h-3.5 w-3.5 shrink-0 transition-transform group-hover:-translate-x-0.5"
+            >
+              <path d="M13 8H3M7 4l-4 4 4 4" />
+            </svg>
             Back to all projects
           </NextLink>
         </div>

--- a/src/components/projects/RelatedPosts.tsx
+++ b/src/components/projects/RelatedPosts.tsx
@@ -27,14 +27,31 @@ const RelatedPosts = ({ slugs }: RelatedPostsProps) => {
       <h2 className="text-sm font-semibold text-gray-500 uppercase tracking-wide mb-3">
         Related reading
       </h2>
-      <ul className="flex flex-col gap-2">
+      <ul className="flex flex-col gap-0.5">
         {relatedPosts.map((post) => (
           <li key={post.slug}>
             <NextLink
               href={`/posts/${post.slug}`}
-              className="text-sm hover:underline"
+              // Negative margin cancels the padding so the arrow sits on the
+              // heading's left edge, letting the icons read as list markers
+              // while the padded hit area stays comfortably large.
+              className="group -ml-3 inline-flex items-start gap-2 rounded-md px-3 py-3 text-sm font-medium transition-colors hover:bg-gray-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#4267b2]"
               style={{ color: "#4267b2" }}
             >
+              <svg
+                aria-hidden="true"
+                viewBox="0 0 16 16"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth={1.75}
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                // mt centres the icon on the first line, so it stays put as a
+                // list marker when a long title wraps on narrow screens.
+                className="mt-[3px] h-3.5 w-3.5 shrink-0 transition-transform group-hover:translate-x-0.5"
+              >
+                <path d="M3 8h10M9 4l4 4-4 4" />
+              </svg>
               {post.title}
             </NextLink>
           </li>


### PR DESCRIPTION
## Summary

The "Back to all projects" link and the related-reading links on project pages were bare text with only a hover underline, giving no affordance beyond colour and a hit area barely taller than the text itself. Both now share one recipe: a directional arrow, a 44px padded tap target with a hover pill, and a keyboard focus ring.

## Changes

- Add directional arrow icons so the links read as navigation rather than generic links: back points left, related posts point right, each sliding on hover. Inline SVG rather than FontAwesome, since FA is only used in client components here and the project page is a server component.
- Grow both to 44px tap targets with a padded hover pill, offset by a negative margin so the arrows align with the body text and the heading.
- Add `focus-visible` rings for keyboard users, using the link colour directly rather than an offset ring, whose white offset rendered as a halo against the page's grey background.
- Anchor the icons to the first text line (`items-start` + `py-3`) so they hold position as list markers when a long title wraps to two or three lines on narrow screens.
- Tighten the related-posts list gap from `gap-2` to `gap-0.5`, since the new padding supplies the separation.

Verified against the dev server by measuring the DOM and CSSOM: icon centres land at 22px from the top for 1-, 2-, and 3-line rows alike; arrows align at the body-text left edge; focus produces a solid 2px `#4267b2` ring under keyboard modality; no horizontal overflow at 375px; lint clean; no console errors.